### PR TITLE
Use ngrok for webhooks

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+LI_IMPORT_AWS_HOST='http://localhost:4569'

--- a/README.md
+++ b/README.md
@@ -30,19 +30,12 @@ export LI_HOST='https://server.livingdocs.io'
 
 Note: make sure to configure an API token that has write rights.
 
-5. Set Importer ENV variables
-
-```
-export LI_IMPORT_WEBHOOK_HOST='http://localhost:3000/dev'
-export LI_IMPORT_AWS_HOST='http://localhost:4569'
-```
-
-6. Start serverless with your profile
+5. Start serverless with your profile
 ```
 AWS_PROFILE=s3local sls offline start
 ```
 
-7. Test the import (in a new cl window)
+6. Test the import (in a new cl window)
 ```
 aws --endpoint http://localhost:4569 s3 cp ./test.json s3://local-bucket/test-transfered-foo.json --profile s3local
 ```

--- a/handler.js
+++ b/handler.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const _ = require('lodash')
 const {getArticlesFromBucket} = require('./lib/s3_helpers')
 const {getImages} = require('./lib/dpa_parsers')

--- a/lib/livingdocs_connector.js
+++ b/lib/livingdocs_connector.js
@@ -11,7 +11,7 @@ module.exports = {
     }
     const documentData = {
       systemName: 'dpa-import-example',
-      webhook: `${process.env.LI_IMPORT_WEBHOOK_HOST}/documents-imported`,
+      webhook: `${process.env.LI_IMPORT_WEBHOOK_HOST}/dev/documents-imported`,
       documents: _.map(articles, (a) => {
         const images = _.reduce(livingdocsImages, (res, i, key) => {
           const association = _.find(a.associations, (ass) => {
@@ -50,7 +50,7 @@ module.exports = {
     }
     const data = {
       systemName: 'dpa-import-example',
-      webhook: `${process.env.LI_IMPORT_WEBHOOK_HOST}/images-imported`,
+      webhook: `${process.env.LI_IMPORT_WEBHOOK_HOST}/dev/images-imported`,
       images: _.map(images, (i) => {
         return {
           url: i.renditions[0].url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -431,6 +431,12 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -447,6 +453,28 @@
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ambi": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
+      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
+      "dev": true,
+      "requires": {
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
       }
     },
     "ansi-align": {
@@ -528,6 +556,21 @@
         "is-string": "^1.0.4"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -541,6 +584,12 @@
       "requires": {
         "lodash": "^4.17.14"
       }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -564,6 +613,18 @@
         "xml2js": "0.4.19"
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "dev": true
+    },
     "axios": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
@@ -581,6 +642,25 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -653,6 +733,12 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "dev": true
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true
+    },
     "busboy": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
@@ -706,6 +792,12 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -717,6 +809,15 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -885,6 +986,15 @@
         "text-hex": "1.0.x"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -1006,6 +1116,15 @@
       "integrity": "sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==",
       "dev": true
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -1026,6 +1145,47 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
+      "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
+      "dev": true,
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
       }
     },
     "deep-eql": {
@@ -1061,6 +1221,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -1134,6 +1300,18 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1351,6 +1529,44 @@
         }
       }
     },
+    "eachr": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.3.0.tgz",
+      "integrity": "sha512-yKWuGwOE283CTgbEuvqXXusLH4VBXnY2nZbDkeWev+cpAXY6zCIADSPLdvfkAROc0t8S4l07U1fateCdEDuuvg==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.2.0",
+        "typechecker": "^4.9.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1359,6 +1575,12 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1396,6 +1618,24 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "envfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-2.3.0.tgz",
+      "integrity": "sha512-xcwno0xGhSVhgBfFx9SxwYd6FNfTdq8SMFjrQ4FYsxYUNQMPJTXn7dERrX439F1V4Ukk9x/nL/5GcNZaIVUT7g==",
+      "dev": true,
+      "requires": {
+        "ambi": "^2.4.0",
+        "eachr": "^3.1.0",
+        "editions": "^1.3.3",
+        "typechecker": "^4.0.1"
+      }
+    },
+    "errlop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+      "dev": true
     },
     "es-abstract": {
       "version": "1.17.6",
@@ -1523,6 +1763,24 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
@@ -1597,6 +1855,23 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1656,6 +1931,15 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1729,6 +2013,22 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -1847,6 +2147,17 @@
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2101,6 +2412,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "iterate-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
@@ -2144,10 +2461,34 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
@@ -2189,6 +2530,18 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "jszip": {
@@ -2419,6 +2772,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lock": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
+      "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0=",
+      "dev": true
     },
     "lodash": {
       "version": "4.17.15",
@@ -2668,6 +3027,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+      "dev": true
+    },
     "mocha": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
@@ -2755,6 +3120,28 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
+    "ngrok": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-2.3.0.tgz",
+      "integrity": "sha512-zRzeTtdwx2tjeeT/GbOdZk8dUR3S3yOW3W+VwkRF4wpCajbP/8u3I3jlP0HyHoiPLb/zpT2PsgqFxM+K9cfclA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^8.0.19",
+        "async": "^2.3.0",
+        "decompress-zip": "^0.3.0",
+        "lock": "^0.1.2",
+        "request": "^2.55.0",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+          "dev": true
+        }
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -2787,6 +3174,15 @@
         "sorted-array-functions": "^1.0.0"
       }
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2815,6 +3211,12 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.8.0",
@@ -3067,6 +3469,12 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -3123,6 +3531,12 @@
         "iterate-value": "^1.0.0"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3146,6 +3560,12 @@
       "requires": {
         "escape-goat": "^2.0.0"
       }
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
     },
     "qs": {
       "version": "6.9.4",
@@ -3237,6 +3657,42 @@
         "rc": "^1.2.8"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3318,6 +3774,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -3361,6 +3823,29 @@
         "randombytes": "^2.1.0"
       }
     },
+    "serverless-dotenv-plugin": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.1.0.tgz",
+      "integrity": "sha512-R9Jld4a/hDDd0lHiSq9xQuFlhtfgXqKKmODrYp7115iQ9kgf16SMxZbxJ0Cb9GqL6/4+5GlS42iHxsqv8GxZeQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "serverless-dynamodb-client": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/serverless-dynamodb-client/-/serverless-dynamodb-client-0.0.2.tgz",
@@ -3378,6 +3863,17 @@
         "bluebird": "^3.4.6",
         "dynamodb-localhost": "0.0.9",
         "lodash": "^4.17.0"
+      }
+    },
+    "serverless-ngrok-tunnel": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/serverless-ngrok-tunnel/-/serverless-ngrok-tunnel-0.0.3.tgz",
+      "integrity": "sha512-ZauVigRbc2fJ0Vn0MgX2E8v8aInXZMDJzlr1huO2DoIeZyuN3KmYmXVtv83p59dir4DC6XLGL1JyqXz8pKlpjQ==",
+      "dev": true,
+      "requires": {
+        "envfile": "^2.3.0",
+        "lodash": "^4.17.10",
+        "ngrok": "2.3.0"
       }
     },
     "serverless-offline": {
@@ -3534,6 +4030,23 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -3701,6 +4214,50 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -3717,6 +4274,21 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-detect": {
@@ -3738,6 +4310,33 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "typechecker": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.11.0.tgz",
+      "integrity": "sha512-lz39Mc/d1UBcF/uQFL5P8L+oWdIn/stvkUgHf0tPRW4aEwGGErewNXo2Nb6We2WslWifn00rhcHbbRWRcTGhuw==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.2.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "typedarray-to-buffer": {
@@ -3785,6 +4384,23 @@
         "xdg-basedir": "^4.0.0"
       }
     },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -3824,6 +4440,17 @@
       "resolved": "https://registry.npmjs.org/velocityjs/-/velocityjs-2.0.0.tgz",
       "integrity": "sha512-ykI/zV9K51pcxOvD8Nd3jzVtRHcgG9w/a/BxsHh4sDwV0ZJAjWJk7Wa2TM5c9MWtCMn+FgqePkQFajwAvcNx7w==",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "mocha": "^8.1.3",
+    "serverless-dotenv-plugin": "^3.1.0",
+    "serverless-ngrok-tunnel": "0.0.3",
     "serverless-offline": "^6.4.0",
     "serverless-plugin-existing-s3": "^2.4.0",
     "serverless-s3-local": "^0.6.2"

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,13 +3,20 @@ plugins:
   - serverless-s3-local
   - serverless-dynamodb-local
   - serverless-offline
+  - serverless-ngrok-tunnel
+  - serverless-dotenv-plugin
 
 provider:
   name: aws
   runtime: nodejs12.x
   profile: s3local
 
-custom: 
+custom:
+  ngrokTunnel:
+    envPath: './.env'
+    tunnels:
+      - port: 3000
+        envProp: 'LI_IMPORT_WEBHOOK_HOST'
   s3:
     host: localhost
     port: 4569

--- a/test.json
+++ b/test.json
@@ -1,44 +1,84 @@
 {
   "format": "digitalwires@0.5.14",
-  "entry_id": "lTereOrxafnfLYwi0XO2QX9V1gznXwLbKCYJEvD3o",
-  "updated": "2020-09-14T10:58:51Z",
-  "urn": "urn:newsml:dpa.com:20090101:200912-99-530987",
-  "version_created": "2020-09-12T11:53:46+02:00",
-  "version": 2,
+  "entry_id": "C5Nya31hq7xQJ0StNZuqIkPZbkw6nwYnxKib1yPWgA",
+  "updated": "2020-10-29T15:22:54Z",
+  "urn": "urn:newsml:dpa.com:20090101:201028-99-107912",
+  "version_created": "2020-10-28T17:35:17+01:00",
+  "version": 7,
   "pubstatus": "usable",
   "embargoed": null,
   "language": "de",
-  "urgency": 4,
-  "kicker": "Superheldinnengeschichte ",
-  "headline": "«Wonder Woman 1984»-Kinostart auf Weihnachten verschoben",
+  "urgency": 3,
+  "kicker": "Macher-Mentalität",
+  "headline": "Chemnitz wird Europäische Kulturhauptstadt 2025 ",
   "subhead": null,
-  "teaser": "Die «Wonder Woman»-Fortsetzung musste wegen Corona auf Oktober verschoben werden. Jetzt startet die Superheldinnengeschichte noch später.",
-  "byline": null,
-  "dateline": "Los Angeles (dpa) - ",
-  "article_html": "<section class=\"main\"><p>«Wonder Woman»-Fans müssen wegen der Coronavirus-Pandemie noch länger auf die Fortsetzung der Superheldinnengeschichte warten. Der Kinostart von «Wonder Woman 1984» werde von Anfang Oktober auf den 25. Dezember verschoben, teilte das Hollywood-Studio Warner Bros. mit.</p><p>Ursprünglich sollte der Film mit Hauptdarstellerin Gal Gadot als Amazonenkämpferin schon Anfang Juni in die US-Kinos kommen. Es folgten weitere Aufschübe, erst auf August, dann auf Oktober.</p><p>«Wir sind sehr stolz auf den Film und freuen uns, ihn den Zuschauern an Weihnachten zu bringen», zitierte das Branchenblatt «Variety» aus einer Mitteilung von Toby Emmerich, Chef der Warner Bros. Pictures Group. Es sei wichtig, diesen Film auf der großen Leinwand zusammen mit anderen Menschen zu erleben, fügte Regisseurin Patty Jenkins hinzu.</p><p>In wichtigen Märkten in den USA, darunter in Los Angeles und New York, sind die Kinos wegen der Coronavirus-Krise noch geschlossen. Zahlreiche Filmstarts sind in den letzten Monaten aufgeschoben worden.</p><p>Der Original-Film «Wonder Woman» mit Gadot, Chris Pine und Robin Wright war 2017 ein großer Kinohit. Jenkins («Monster») hat die Fortsetzung an vielen Schauplätzen in drei Ländern gedreht.</p></section>",
+  "teaser": "Acht Städte wollten gern, fünf waren noch im Rennen, doch nur Chemnitz wird Europäische Kulturhauptstadt 2025. In den riesigen Jubel der sächsischen Stadt mischen sich Appelle für Offenheit und Solidarität.",
+  "byline": "Von Gerd Roth, dpa",
+  "dateline": "Berlin (dpa) - ",
+  "article_html": "<section class=\"main\"><p>Chemnitz soll für Deutschland im Jahr 2025 als Europäische Kulturhauptstadt Solidarität und Kooperation verkörpern. Die sächsische Stadt setzte sich am Mittwoch in Berlin gegen die auf der Shortlist noch vertretenen Städte Hannover, Hildesheim, Magdeburg und Nürnberg durch.</p><p>Eine entsprechende Empfehlung für Chemnitz verkündete die europäische Auswahljury. Zuvor waren im Dezember die Mitbewerber Dresden, Gera und Zittau ausgeschieden.</p><p>Die Jury-Vorsitzende Sylvia Amann forderte Chemnitz und auch die unterlegenen Bewerber auf, Kunst und Kultur in den Mittelpunkt zu stellen und als Teil der Lösung der aktuellen Probleme zu verstehen. «Europa braucht jetzt mehr denn je ein Klima der Offenheit und der Solidarität», sagte Amann. Kunst, Kultur und das Engagement auf städtischer Ebene könnten dies leisten.</p><p>Die Empfehlung der Jury muss von Bund und Ländern noch in eine formelle Ernennung umgewandelt werden. Die zweite Europäische Kulturhauptstadt 2025 stellt Slowenien, die Entscheidung soll im Dezember verkündet werden. In diesem Jahr können sich Rijeka in Kroatien und Galway in Irland mit dem Titel schmücken.</p><p>Jüngste Europäische Kulturhauptstadt aus Deutschland war Essen mit dem Ruhrgebiet (2010). Ausgezeichnet wurden davor auch schon Weimar (1999) und West-Berlin (1988).</p><p>Während es in den unterlegenen Städten lange Gesichter gab, zeigte sich die Chemnitzer Oberbürgermeisterin Barbara Ludwig begeistert. «Es wird der Stadt so gut tun», sagte die SPD-Politikerin. Chemnitz war vor zwei Jahren tagelang bundesweit in den Blickpunkt geraten. Nachdem am Rande eines Stadtfests ein Mann von einem Asylbewerber erstochen worden war, folgten Übergriffe und Demonstrationen, die auch von Rechtsextremen instrumentalisiert wurden.</p><p>«Die Ereignisse haben die Stadt in einer Art und Weise an ihre Grenzen gebracht hat, die uns zum Teil sehr wehgetan haben», sagte die scheidende Stadtchefin an ihrem vorletzten Amtstag. Das habe eine neue Bewegung ausgelöst. «Wir wollen zeigen, dass wir so viel mehr sind als die Bilder, die 2018 um die Welt gegangen sind.»</p><p>Chemnitz will «all die Leute und Orte sichtbar machen, die man nicht sieht, und damit auch ein Chemnitz, das in Europa - noch - keiner auf dem Schirm hat», so das Bewerbungsteam. Mit kulturellen Mitteln sollen Gräben überwunden werden.</p><p>In den Bewerberstädten wurden jahrelang Ideen gewälzt, Programme aufgestellt und dicke Bewerbungen geschrieben. Die Kandidaten wurden aufgrund umfangreicher Bewerbungsbücher bewertet. Außerdem gab es zuletzt Stadtbesuche, wegen der Corona-Pandemie allerdings ausschließlich digital.</p><p>Aus Sicht von Kulturstaatsministerin Monika Grütters (CDU) haben die Bewerberstädte gezeigt, «wie vielfältig, bunt und belebend unsere Kulturlandschaft in ganz Deutschland ist». Chemnitz habe die Jury «mit einem dezidiert politischen Konzept überzeugt und dabei gezeigt: kulturelle Vielfalt ist stärker als populistische Einfalt». Deutschland könne sich 2025 «wieder mit einer vielversprechenden Kulturmetropole der europäischen Öffentlichkeit präsentieren».</p><p>Sachsens Kulturministerin Barbara Klepsch (CDU) bezeichnete die Entscheidung für Chemnitz in einer für Kunst- und Kulturschaffende schwierigen Zeit als Lichtblick. Für die Kulturministerkonferenz der Länder sagte Bayerns Kunstminister Bernd Sibler (CSU), der Wettbewerb mache «Kultur zum Impulsgeber für eine langfristige Stadtentwicklung und für den gesellschaftlichen Zusammenhalt». Aus Sicht von Markus Hilgert, Generalsekretär der Kulturstiftung der Länder, haben die Bewerberstädte gezeigt, «welche integrative, verbindende und gemeinschaftsstiftende Kraft Kultur hat».</p></section>",
   "infobox_html": null,
-  "linkbox_html": "<section class=\"linkbox\"><ul><li><a href=\"http://dpaq.de/uYhxx\">Variety</a></li><li><a href=\"http://dpaq.de/uY20K\">Hollywood Reporter</a></li></ul></section>",
+  "linkbox_html": "<section class=\"linkbox\"><ul><li><a href=\"http://dpaq.de/yOn62\">Kulturstiftung zu Bewerbern</a></li><li><a href=\"http://dpaq.de/EvE1Y\">YouTube-Kanal der Kulturstiftung der Länder</a></li><li><a href=\"http://dpaq.de/EpXBZ\">Kulturhauptstädte Europas</a></li><li><a href=\"http://dpaq.de/ePRub\">Bewerbungskriterien</a></li><li><a href=\"http://dpaq.de/IhcNs\">Juryreport</a></li><li><a href=\"http://dpaq.de/FUITt\">Kulturhauptstadt Magdeburg 2025</a></li><li><a href=\"http://dpaq.de/FRMSh\">Kulturhauptstadt Nürnberg 2025</a></li><li><a href=\"http://dpaq.de/FjHtI\">Kulturhauptstadt Hildesheim 2025</a></li><li><a href=\"http://dpaq.de/TSGO7\">Kulturhauptstadt Hannover 2025</a></li><li><a href=\"http://dpaq.de/qBs4V\">Kulturhauptstadt Chemnitz 2025</a></li></ul></section>",
   "creditline": "dpa",
   "copyrightnotice": "Copyright 2020, dpa (www.dpa.de). Alle Rechte vorbehalten",
   "notepad": null,
   "associations": [
     {
       "type": "image",
-      "urn": "urn:newsml:dpa.com:20090101:200912-99-531693",
-      "version": 2,
+      "urn": "urn:newsml:dpa.com:20090101:201028-99-114689",
+      "version": 3,
       "rank": 1,
-      "version_created": "2020-09-12T11:53:20+02:00",
-      "headline": "Gal Gadot",
+      "version_created": "2020-10-28T13:29:11+01:00",
+      "headline": "Chemnitz",
       "is_featureimage": true,
-      "caption": "Die «Wonder Woman»-Fortsetzung mit Gal Gadot wird ein weiteres Mal verschoben.",
-      "creditline": "Jordan Strauss/Invision/AP/dpa",
+      "caption": "Die Majolika-Häuser auf dem Kaßberg in Chemitz.",
+      "creditline": "Hendrik Schmidt/dpa-Zentralbild/dpa",
       "renditions": [
         {
           "size": 2048,
           "width": 2048,
-          "height": 1366,
+          "height": 1324,
           "mimetype": "image/jpeg",
-          "url": "https://d3hzhyitlnc455.cloudfront.net/v3/image/resize/urn:newsml:dpa.com:20090101:200912-99-531693-v2-s2048.jpeg?signature=PNk-nvOdbUKboecCj_AzTNixoyU&expires=1600214400"
+          "url": "https://d3hzhyitlnc455.cloudfront.net/v3/image/resize/urn:newsml:dpa.com:20090101:201028-99-114689-v3-s2048.jpeg?signature=Vf5RT9K7GyydFXAQ7jOVH-7PjSk&expires=1604188800"
+        }
+      ]
+    },
+    {
+      "type": "image",
+      "urn": "urn:newsml:dpa.com:20090101:201028-99-114710",
+      "version": 3,
+      "rank": 2,
+      "version_created": "2020-10-28T13:30:10+01:00",
+      "headline": "Chemnitz",
+      "is_featureimage": false,
+      "caption": "Blick auf das Opernhaus im Zentrum von Chemnitz.",
+      "creditline": "Hendrik Schmidt/dpa-Zentralbild/dpa",
+      "renditions": [
+        {
+          "size": 2048,
+          "width": 2048,
+          "height": 1323,
+          "mimetype": "image/jpeg",
+          "url": "https://d3hzhyitlnc455.cloudfront.net/v3/image/resize/urn:newsml:dpa.com:20090101:201028-99-114710-v3-s2048.jpeg?signature=eRGbOa68CIh4q2SDfPKihG4fw-0&expires=1604188800"
+        }
+      ]
+    },
+    {
+      "type": "image",
+      "urn": "urn:newsml:dpa.com:20090101:201028-99-114773",
+      "version": 3,
+      "rank": 3,
+      "version_created": "2020-10-28T13:33:41+01:00",
+      "headline": "Chemnitz",
+      "is_featureimage": false,
+      "caption": "Blick auf das Karl-Marx-Monument im Zentrum  von Chemnitz.",
+      "creditline": "Hendrik Schmidt/dpa-Zentralbild/dpa",
+      "renditions": [
+        {
+          "size": 2048,
+          "width": 2048,
+          "height": 1400,
+          "mimetype": "image/jpeg",
+          "url": "https://d3hzhyitlnc455.cloudfront.net/v3/image/resize/urn:newsml:dpa.com:20090101:201028-99-114773-v3-s2048.jpeg?signature=eV1VCFwzieyQR-ElNqK41kdJaYw&expires=1604188800"
         }
       ]
     }
@@ -46,100 +86,267 @@
   "categories": [
     {
       "type": "dnltype:rubric",
-      "name": "weblines.infoline_rs.boulevard.kultur",
-      "qcode": "dnlpath:weblines.infoline_rs.boulevard.kultur",
+      "name": "weblines.infoline.brennpunkte",
+      "qcode": "dnlpath:weblines.infoline.brennpunkte",
       "is_current": false
     },
     {
       "type": "dnltype:rubric",
-      "name": "weblines.starline.kino",
-      "qcode": "dnlpath:weblines.starline.kino",
+      "name": "weblines.infoline_rs.boulevard.kultur",
+      "qcode": "dnlpath:weblines.infoline_rs.boulevard.kultur",
+      "is_current": true
+    },
+    {
+      "type": "dnltype:rubric",
+      "name": "weblines.infoline_rs.panorama",
+      "qcode": "dnlpath:weblines.infoline_rs.panorama",
+      "is_current": false
+    },
+    {
+      "type": "dnltype:rubric",
+      "name": "weblines.starline.kulturwelt",
+      "qcode": "dnlpath:weblines.starline.kulturwelt",
       "is_current": true
     },
     {
       "type": "dnltype:rubric",
       "name": "weblines.starline.topnews",
       "qcode": "dnlpath:weblines.starline.topnews",
-      "is_current": false
+      "is_current": true
     },
     {
       "type": "dnltype:dpasubject",
-      "name": "Film",
-      "qcode": "dpasubject:119",
-      "rank": 1
-    },
-    {
-      "type": "dnltype:dpasubject",
-      "name": "Leute",
-      "qcode": "dpasubject:521",
-      "rank": 2
-    },
-    {
-      "type": "dnltype:keyword",
-      "name": "Gal Gadot",
-      "qcode": null,
+      "name": "Kultur",
+      "qcode": "dpasubject:147",
       "rank": 1
     },
     {
       "type": "dnltype:keyword",
-      "name": "Wonder Woman",
+      "name": "Kulturhauptstadt",
       "qcode": null,
+      "rank": 1
+    },
+    {
+      "type": "dnltype:geosubject",
+      "name": "Deutschland",
+      "qcode": "dpacountry:1",
+      "rank": 1
+    },
+    {
+      "type": "dnltype:geosubject",
+      "name": "Sachsen",
+      "qcode": "dpaarea:13",
       "rank": 2
     },
     {
-      "type": "dnltype:keyword",
-      "name": "Corona",
-      "qcode": null,
+      "type": "dnltype:geosubject",
+      "name": "Sachsen-Anhalt",
+      "qcode": "dpaarea:14",
       "rank": 3
     },
     {
       "type": "dnltype:geosubject",
-      "name": "USA",
-      "qcode": "dpacountry:184",
-      "rank": 1
+      "name": "Niedersachsen",
+      "qcode": "dpaarea:9",
+      "rank": 4
+    },
+    {
+      "type": "dnltype:geosubject",
+      "name": "Bayern",
+      "qcode": "dpaarea:2",
+      "rank": 5
+    },
+    {
+      "type": "dnltype:geosubject",
+      "name": "Europa",
+      "qcode": null,
+      "rank": 6
     },
     {
       "type": "dnltype:desk",
-      "name": "ku",
+      "name": "Kultur",
       "qcode": "dpacat:ku"
     },
     {
       "type": "dnltype:genre",
-      "name": "Meldung",
-      "qcode": "dpatextgenre:1"
+      "name": "Zusammenfassung",
+      "qcode": "dpatextgenre:26"
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Kulturstiftung der Länder, Lützowpl. 9, 10785 Berlin, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Kulturstiftung der Länder",
+          "formatted_address": "Lützowpl. 9, 10785 Berlin, Deutschland",
+          "locality": "Berlin",
+          "administrative_area_level_1": "Berlin",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            13.35374,
+            52.50437
+          ]
+        }
+      }
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Chemnitz, Chemnitz, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Chemnitz",
+          "formatted_address": "Chemnitz, Deutschland",
+          "locality": "Chemnitz",
+          "administrative_area_level_1": "Sachsen",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            12.9213697,
+            50.827845
+          ]
+        }
+      }
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Hannover, Hannover, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Hannover",
+          "formatted_address": "Hannover, Deutschland",
+          "locality": "Hannover",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            9.7320104,
+            52.3758916
+          ]
+        }
+      }
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Hildesheim, Hildesheim, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Hildesheim",
+          "formatted_address": "Hildesheim, Deutschland",
+          "locality": "Hildesheim",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            9.9579652,
+            52.154778
+          ]
+        }
+      }
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Nürnberg, Nürnberg, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Nürnberg",
+          "formatted_address": "Nürnberg, Deutschland",
+          "locality": "Nürnberg",
+          "administrative_area_level_1": "Bayern",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            11.0766654,
+            49.4521018
+          ]
+        }
+      }
+    },
+    {
+      "type": "dnltype:poi",
+      "name": "Magdeburg, Magdeburg, Deutschland",
+      "qcode": null,
+      "geojson": {
+        "type": "Feature",
+        "properties": {
+          "name": "Magdeburg",
+          "formatted_address": "Magdeburg, Deutschland",
+          "locality": "Magdeburg",
+          "administrative_area_level_1": "Sachsen-Anhalt",
+          "country": "Deutschland"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            11.6276237,
+            52.1205333
+          ]
+        }
+      }
     },
     {
       "type": "dnltype:urgency",
-      "name": "4",
-      "qcode": "urgency:4"
+      "name": "3",
+      "qcode": "urgency:3"
     }
   ],
   "current_rubric_names": [
-    "weblines.starline.kino"
+    "weblines.infoline_rs.boulevard.kultur",
+    "weblines.starline.kulturwelt",
+    "weblines.starline.topnews"
   ],
   "rubric_names": [
+    "weblines.infoline.brennpunkte",
     "weblines.infoline_rs.boulevard.kultur",
-    "weblines.starline.kino",
+    "weblines.infoline_rs.panorama",
+    "weblines.starline.kulturwelt",
     "weblines.starline.topnews"
   ],
   "dpasubject_names": [
-    "Film",
-    "Leute"
+    "Kultur"
   ],
   "geosubject_names": [
-    "USA"
+    "Deutschland",
+    "Sachsen",
+    "Sachsen-Anhalt",
+    "Niedersachsen",
+    "Bayern",
+    "Europa"
   ],
   "keyword_names": [
-    "Gal Gadot",
-    "Wonder Woman",
-    "Corona"
+    "Kulturhauptstadt"
   ],
   "desk_names": [
     "ku"
   ],
   "genre_names": [
-    "Meldung"
+    "Zusammenfassung"
   ],
-  "poi_names": [],
+  "poi_names": [
+    "Kulturstiftung der Länder, Lützowpl. 9, 10785 Berlin, Deutschland",
+    "Chemnitz, Chemnitz, Deutschland",
+    "Hannover, Hannover, Deutschland",
+    "Hildesheim, Hildesheim, Deutschland",
+    "Nürnberg, Nürnberg, Deutschland",
+    "Magdeburg, Magdeburg, Deutschland"
+  ],
   "scope_names": []
 }


### PR DESCRIPTION
Previously, we used `localhost` to register the webhook for reporting back when the images are imported and in turn trigger the document import. Unfortunately, when the actual Livingdocs service at https://edit.livingdocs.io was used this could of course not report back to a localhost address on the computer of the developer.
In order to mitigate this, we use ngrok to run the serverless local app on an ngrok endpoint that is reachable in the Internet.